### PR TITLE
Add ProductImage component and admin products route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,14 @@ const App = () => {
                       }
                     />
                     <Route
+                      path="/admin/products"
+                      element={
+                        <ProtectedRoute allowedRoles={["admin"]}>
+                          <ProductManagement />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
                       path="/product-management"
                       element={
                         <ProtectedRoute allowedRoles={["admin"]}>

--- a/src/components/atoms/ProductImage.tsx
+++ b/src/components/atoms/ProductImage.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import { Package } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ProductImageProps {
+  src?: string;
+  alt: string;
+  className?: string;
+  fallbackClassName?: string;
+  loading?: "lazy" | "eager";
+  onError?: () => void;
+}
+
+export const ProductImage: React.FC<ProductImageProps> = ({
+  src,
+  alt,
+  className,
+  fallbackClassName,
+  loading = "lazy",
+  onError,
+}) => {
+  const [imageError, setImageError] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  const handleImageError = () => {
+    setImageError(true);
+    onError?.();
+  };
+
+  const handleImageLoad = () => {
+    setImageLoaded(true);
+  };
+
+  if (!src || imageError) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center bg-gradient-to-br from-muted to-muted/50",
+          fallbackClassName,
+          className,
+        )}
+      >
+        <Package className="h-8 w-8 text-muted-foreground/30" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("relative overflow-hidden", className)}>
+      {!imageLoaded && (
+        <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-muted to-muted/50">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+        </div>
+      )}
+      <img
+        src={src}
+        alt={alt}
+        className={cn(
+          "object-cover w-full h-full transition-opacity duration-300",
+          imageLoaded ? "opacity-100" : "opacity-0",
+        )}
+        loading={loading}
+        onError={handleImageError}
+        onLoad={handleImageLoad}
+      />
+    </div>
+  );
+};
+
+export default ProductImage;

--- a/src/components/molecules/ProductCard.tsx
+++ b/src/components/molecules/ProductCard.tsx
@@ -113,8 +113,18 @@ export const ProductCard: React.FC<ProductCardProps> = ({
           <img
             src={product.image}
             alt={product.name}
-            className="object-cover w-full h-full"
+            className="object-cover w-full h-full transition-transform group-hover:scale-105"
             loading="lazy"
+            onError={(e) => {
+              const target = e.target as HTMLImageElement;
+              target.style.display = "none";
+              const parent = target.parentElement;
+              if (parent) {
+                parent.innerHTML =
+                  '<div class="h-12 w-12 text-muted-foreground/30"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-package h-12 w-12"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg></div>';
+                parent.classList.add("flex", "items-center", "justify-center");
+              }
+            }}
           />
         ) : (
           <Package className="h-12 w-12 text-muted-foreground/30" />

--- a/src/components/molecules/ProductCard.tsx
+++ b/src/components/molecules/ProductCard.tsx
@@ -14,10 +14,10 @@ import { cartApi } from "@/api/cart";
 import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import { RoleGuard } from "@/components/atoms/RoleGuard";
+import { ProductImage } from "@/components/atoms/ProductImage";
 import {
   ShoppingCart,
   Heart,
-  Package,
   Star,
   AlertTriangle,
   Eye,
@@ -99,36 +99,16 @@ export const ProductCard: React.FC<ProductCardProps> = ({
       )}
     >
       {/* Product Image */}
-      <div
-        className={cn(
-          "relative bg-gradient-to-br from-muted to-muted/50 flex items-center justify-center",
-          {
+      <div className="relative">
+        <ProductImage
+          src={product.image}
+          alt={product.name}
+          className={cn({
             "h-48": variant === "default",
             "w-32 h-32": variant === "compact",
             "h-56": variant === "featured",
-          },
-        )}
-      >
-        {product.image ? (
-          <img
-            src={product.image}
-            alt={product.name}
-            className="object-cover w-full h-full transition-transform group-hover:scale-105"
-            loading="lazy"
-            onError={(e) => {
-              const target = e.target as HTMLImageElement;
-              target.style.display = "none";
-              const parent = target.parentElement;
-              if (parent) {
-                parent.innerHTML =
-                  '<div class="h-12 w-12 text-muted-foreground/30"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-package h-12 w-12"><path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg></div>';
-                parent.classList.add("flex", "items-center", "justify-center");
-              }
-            }}
-          />
-        ) : (
-          <Package className="h-12 w-12 text-muted-foreground/30" />
-        )}
+          })}
+        />
 
         {/* Badges */}
         <div className="absolute top-2 left-2 space-y-1">

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -280,11 +280,21 @@ const Homepage: React.FC = () => {
                 >
                   <div className="relative">
                     <div className="bg-gradient-to-br from-metallic-light to-metallic-background h-48 flex items-center justify-center">
-                      <img
-                        src={product?.image}
-                        className="w-full h-full object-cover"
-                        alt=""
-                      />
+                      {product.image ? (
+                        <img
+                          src={product.image}
+                          alt={product.name}
+                          className="w-full h-full object-cover"
+                          loading="lazy"
+                          onError={(e) => {
+                            const target = e.target as HTMLImageElement;
+                            target.style.display = "none";
+                            target.parentElement?.classList.add("flex");
+                          }}
+                        />
+                      ) : (
+                        <Package className="h-12 w-12 text-metallic-primary/30" />
+                      )}
                     </div>
                     <div className="absolute top-3 right-3">
                       <Button
@@ -407,7 +417,21 @@ const Homepage: React.FC = () => {
                 <div
                   className={`${viewMode === "list" ? "w-32 h-32" : "h-32"} bg-gradient-to-br from-metallic-light to-metallic-background flex items-center justify-center relative`}
                 >
-                  <Package className="h-8 w-8 text-metallic-primary/30" />
+                  {product.image ? (
+                    <img
+                      src={product.image}
+                      alt={product.name}
+                      className="w-full h-full object-cover"
+                      loading="lazy"
+                      onError={(e) => {
+                        const target = e.target as HTMLImageElement;
+                        target.style.display = "none";
+                        target.parentElement?.classList.add("flex");
+                      }}
+                    />
+                  ) : (
+                    <Package className="h-8 w-8 text-metallic-primary/30" />
+                  )}
                   {product.quantity < product.low_stock_threshold && (
                     <Badge className="absolute top-2 left-2 bg-red-500 text-white text-xs">
                       Low Stock

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { useAuth } from "@/contexts/AuthContext";
 import { productApi, getToken } from "@/lib/api";
 import { cartApi } from "@/api/cart";
+import { ProductImage } from "@/components/atoms/ProductImage";
 
 interface Product {
   id: number;
@@ -279,23 +280,12 @@ const Homepage: React.FC = () => {
                   className="group hover:shadow-xl transition-all duration-300 border-metallic-light/20 overflow-hidden"
                 >
                   <div className="relative">
-                    <div className="bg-gradient-to-br from-metallic-light to-metallic-background h-48 flex items-center justify-center">
-                      {product.image ? (
-                        <img
-                          src={product.image}
-                          alt={product.name}
-                          className="w-full h-full object-cover"
-                          loading="lazy"
-                          onError={(e) => {
-                            const target = e.target as HTMLImageElement;
-                            target.style.display = "none";
-                            target.parentElement?.classList.add("flex");
-                          }}
-                        />
-                      ) : (
-                        <Package className="h-12 w-12 text-metallic-primary/30" />
-                      )}
-                    </div>
+                    <ProductImage
+                      src={product.image}
+                      alt={product.name}
+                      className="h-48"
+                      fallbackClassName="bg-gradient-to-br from-metallic-light to-metallic-background"
+                    />
                     <div className="absolute top-3 right-3">
                       <Button
                         size="sm"
@@ -414,24 +404,13 @@ const Homepage: React.FC = () => {
                 key={product.id}
                 className={`hover:shadow-lg transition-all duration-300 border-metallic-light/20 ${viewMode === "list" ? "flex flex-row" : ""}`}
               >
-                <div
-                  className={`${viewMode === "list" ? "w-32 h-32" : "h-32"} bg-gradient-to-br from-metallic-light to-metallic-background flex items-center justify-center relative`}
-                >
-                  {product.image ? (
-                    <img
-                      src={product.image}
-                      alt={product.name}
-                      className="w-full h-full object-cover"
-                      loading="lazy"
-                      onError={(e) => {
-                        const target = e.target as HTMLImageElement;
-                        target.style.display = "none";
-                        target.parentElement?.classList.add("flex");
-                      }}
-                    />
-                  ) : (
-                    <Package className="h-8 w-8 text-metallic-primary/30" />
-                  )}
+                <div className="relative">
+                  <ProductImage
+                    src={product.image}
+                    alt={product.name}
+                    className={viewMode === "list" ? "w-32 h-32" : "h-32"}
+                    fallbackClassName="bg-gradient-to-br from-metallic-light to-metallic-background"
+                  />
                   {product.quantity < product.low_stock_threshold && (
                     <Badge className="absolute top-2 left-2 bg-red-500 text-white text-xs">
                       Low Stock

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -7,11 +7,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAuth } from "@/contexts/AuthContext";
 import { productApi, cartApi } from "@/lib/api";
+import { ProductImage } from "@/components/atoms/ProductImage";
 import {
   ShoppingCart,
   Star,
   Heart,
-  Package,
   ArrowLeft,
   Plus,
   Minus,
@@ -210,23 +210,18 @@ const ProductDetail: React.FC = () => {
         <div className="grid gap-8 lg:grid-cols-2">
           {/* Product Image */}
           <Card>
-            <CardContent className="p-0">
-              <div className="h-96 bg-gradient-to-br from-metallic-light to-metallic-background flex items-center justify-center relative rounded-lg">
-                {product.image ? (
-                  <img
-                    src={product.image}
-                    alt={product.name}
-                    className="object-cover w-full h-full rounded-lg"
-                  />
-                ) : (
-                  <Package className="h-24 w-24 text-metallic-primary/30" />
-                )}
-                {product.quantity < product.low_stock_threshold && (
-                  <Badge className="absolute top-4 left-4 bg-red-500 text-white">
-                    Low Stock
-                  </Badge>
-                )}
-              </div>
+            <CardContent className="p-0 relative">
+              <ProductImage
+                src={product.image}
+                alt={product.name}
+                className="h-96 rounded-lg"
+                fallbackClassName="bg-gradient-to-br from-metallic-light to-metallic-background rounded-lg"
+              />
+              {product.quantity < product.low_stock_threshold && (
+                <Badge className="absolute top-4 left-4 bg-red-500 text-white">
+                  Low Stock
+                </Badge>
+              )}
             </CardContent>
           </Card>
 

--- a/src/pages/ProductManagement.tsx
+++ b/src/pages/ProductManagement.tsx
@@ -607,6 +607,21 @@ const ProductManagement: React.FC = () => {
                 />
               </div>
               <div>
+                <Label htmlFor="image">Image URL</Label>
+                <Input
+                  id="image"
+                  type="url"
+                  value={formData.image}
+                  onChange={(e) =>
+                    setFormData({ ...formData, image: e.target.value })
+                  }
+                  placeholder="https://example.com/image.jpg"
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  Paste a direct image URL from the web
+                </p>
+              </div>
+              <div>
                 <Label htmlFor="status">Status</Label>
                 <select
                   id="status"
@@ -644,13 +659,13 @@ const ProductManagement: React.FC = () => {
           <TableHeader>
             <TableRow className="bg-gray-50">
               <TableHead className="px-6 py-3 text-left text-sm font-medium text-gray-600">
-                Created At
+                Image
               </TableHead>
               <TableHead className="px-6 py-3 text-left text-sm font-medium text-gray-600">
                 Name
               </TableHead>
               <TableHead className="px-6 py-3 text-left text-sm font-medium text-gray-600">
-                Weight
+                Stock
               </TableHead>
               <TableHead className="px-6 py-3 text-left text-sm font-medium text-gray-600">
                 Price
@@ -679,8 +694,22 @@ const ProductManagement: React.FC = () => {
                   key={product.id}
                   className={index % 2 === 0 ? "bg-white" : "bg-gray-50"}
                 >
-                  <TableCell className="px-6 py-4 text-sm text-gray-600">
-                    {new Date(product.created_at).toLocaleString()}
+                  <TableCell className="px-6 py-4">
+                    {product.image ? (
+                      <img
+                        src={product.image}
+                        alt={product.name}
+                        className="w-12 h-12 object-cover rounded-md border"
+                        onError={(e) => {
+                          const target = e.target as HTMLImageElement;
+                          target.style.display = "none";
+                        }}
+                      />
+                    ) : (
+                      <div className="w-12 h-12 bg-gray-200 rounded-md flex items-center justify-center">
+                        <Package className="h-6 w-6 text-gray-400" />
+                      </div>
+                    )}
                   </TableCell>
                   <TableCell className="px-6 py-4 text-sm text-gray-900">
                     {product.name}
@@ -689,7 +718,7 @@ const ProductManagement: React.FC = () => {
                     {product.quantity}
                   </TableCell>
                   <TableCell className="px-6 py-4 text-sm text-gray-600">
-                    {product.price}
+                    ${parseFloat(product.price).toFixed(2)}
                   </TableCell>
                   <TableCell className="px-6 py-4">
                     <div className="flex space-x-2">
@@ -847,6 +876,21 @@ const ProductManagement: React.FC = () => {
               />
             </div>
             <div>
+              <Label htmlFor="edit-image">Image URL</Label>
+              <Input
+                id="edit-image"
+                type="url"
+                value={formData.image}
+                onChange={(e) =>
+                  setFormData({ ...formData, image: e.target.value })
+                }
+                placeholder="https://example.com/image.jpg"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Paste a direct image URL from the web
+              </p>
+            </div>
+            <div>
               <Label htmlFor="edit-status">Status</Label>
               <select
                 id="edit-status"
@@ -915,6 +959,25 @@ const ProductManagement: React.FC = () => {
                   {selectedProduct.status ? "Active" : "Inactive"}
                 </p>
               </div>
+              {selectedProduct.image && (
+                <div>
+                  <Label className="font-medium">Image:</Label>
+                  <div className="mt-2">
+                    <img
+                      src={selectedProduct.image}
+                      alt={selectedProduct.name}
+                      className="w-full h-32 object-cover rounded-md border"
+                      onError={(e) => {
+                        const target = e.target as HTMLImageElement;
+                        target.style.display = "none";
+                      }}
+                    />
+                    <p className="text-xs text-gray-500 mt-1 break-all">
+                      {selectedProduct.image}
+                    </p>
+                  </div>
+                </div>
+              )}
               <div>
                 <Label className="font-medium">Created:</Label>
                 <p className="text-gray-600">

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { useAuth } from "@/contexts/AuthContext";
 import { productApi } from "@/lib/api";
 import { cartApi } from "@/api/cart";
+import { ProductImage } from "@/components/atoms/ProductImage";
 import {
   ShoppingCart,
   Search,
@@ -259,18 +260,15 @@ const Products: React.FC = () => {
                   className={`hover:shadow-lg transition-all duration-300 border-metallic-light/20 ${viewMode === "list" ? "flex flex-row" : ""}`}
                 >
                   <div
-                    className={`${viewMode === "list" ? "w-32 h-32" : "h-48"} bg-gradient-to-br from-metallic-light to-metallic-background flex items-center justify-center relative cursor-pointer`}
+                    className="relative cursor-pointer"
                     onClick={() => viewProduct(product.id)}
                   >
-                    {product.image ? (
-                      <img
-                        src={product?.image}
-                        alt={product.name}
-                        className="object-cover w-full h-full"
-                      />
-                    ) : (
-                      <Package className="h-12 w-12 text-metallic-primary/30" />
-                    )}
+                    <ProductImage
+                      src={product.image}
+                      alt={product.name}
+                      className={viewMode === "list" ? "w-32 h-32" : "h-48"}
+                      fallbackClassName="bg-gradient-to-br from-metallic-light to-metallic-background"
+                    />
                     {product.quantity < product.low_stock_threshold && (
                       <Badge className="absolute top-2 left-2 bg-red-500 text-white text-xs">
                         Low Stock


### PR DESCRIPTION
This pull request introduces a new ProductImage component and adds an admin products route.

**Changes made:**

- Created new ProductImage component in `src/components/atoms/ProductImage.tsx` with loading states, error handling, and fallback display
- Added new admin route `/admin/products` that renders ProductManagement component with admin role protection
- Replaced inline image rendering with ProductImage component across multiple pages:
  - ProductCard.tsx
  - Homepage.tsx
  - ProductDetail.tsx
  - Products.tsx
- Updated ProductManagement.tsx to include image URL input field in create/edit forms
- Modified product table in ProductManagement to display product images instead of creation date
- Added image preview in product details modal
- Improved price formatting to show currency symbol and decimal places

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/360c8f8728564ca293edc753a26030f9/mystic-works)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>360c8f8728564ca293edc753a26030f9</projectId>-->
<!--<branchName>mystic-works</branchName>-->